### PR TITLE
fix: Attack button stucks grey when sending revolt attack

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -10276,6 +10276,11 @@ function DIO_GAME(dio_version, gm, DATA, time_a) {
     var SentUnits = {
         activate: function () {
             $.Observer(uw.GameEvents.command.send_unit).subscribe('DIO_SEND_UNITS', function (e, data) {
+                if (data.sending_type === "revolt"){
+                    // We handle revolt in the same pool as a regular attack.
+                    data.sending_type = "attack";
+                }
+
                 for (var z in data.params) {
                     if (data.params.hasOwnProperty(z) && (data.sending_type !== "")) {
                         if (uw.GameData.units[z]) {


### PR DESCRIPTION
Bug description:
When you send an attack and the Revolt attack type is selected, right after you send the attack, the attack button becomes grey, making it impossible to send the attack again until the window is refreshed.

Proof of fix:

https://user-images.githubusercontent.com/17320094/200068812-61f61b13-5be6-4ee9-9a08-ff2bed4ea624.mp4